### PR TITLE
Fix build-libs.sh

### DIFF
--- a/build-libs.sh
+++ b/build-libs.sh
@@ -6,7 +6,6 @@ if ! command -v xmllint &> /dev/null; then
     exit 1
 fi
 
-
 LIBS_DIR="libs"
 TARGET_FRAMEWORK="net7.0"
 rm -rf $LIBS_DIR

--- a/provisioning/Dockerfile
+++ b/provisioning/Dockerfile
@@ -12,7 +12,7 @@ RUN dotnet publish -o /app/bannou-service/publish -c Release /app/bannou-service
 
 FROM mcr.microsoft.com/dotnet/aspnet:7.0
 COPY --from=intermediate /app/bannou-service/publish /app
-COPY --from=intermediate /app/libs /libs
+COPY --from=intermediate /app/libs /app/libs
 COPY --from=intermediate /root/.dotnet/corefx/cryptography/x509stores/my/* /root/.dotnet/corefx/cryptography/x509stores/my/
 COPY --from=intermediate /root/.dotnet/corefx/cryptography/x509stores/my/* /certificates/
 


### PR DESCRIPTION
## Reason for update

Libs aren't being built and copied over properly when the dockerfile runs the `build-libs.sh` shell script. This will probably be resolved by switching from `msbuild` to `dotnet build` for the command to run (this being from Ubuntu, not Visual Studio).
