### PR TITLE
Use Newtonsoft.Json for text serialization

### DIFF
--- a/bannou-service/Controllers/Messages/ServiceRequest.cs
+++ b/bannou-service/Controllers/Messages/ServiceRequest.cs
@@ -1,8 +1,6 @@
-﻿using System.Text.Json.Serialization;
+﻿namespace BeyondImmersion.BannouService.Controllers.Messages;
 
-namespace BeyondImmersion.BannouService.Controllers.Messages;
-
-[Serializable]
+[JsonObject]
 public class ServiceRequest<T> : ServiceRequest
 where T : class, IServiceResponse, new()
 {
@@ -16,7 +14,7 @@ where T : class, IServiceResponse, new()
 /// <summary>
 /// The basic service message payload model.
 /// </summary>
-[Serializable]
+[JsonObject]
 public class ServiceRequest : IServiceRequest
 {
     [HeaderArray(Name = "REQUEST_IDS")]

--- a/bannou-service/Controllers/Messages/ServiceResponse.cs
+++ b/bannou-service/Controllers/Messages/ServiceResponse.cs
@@ -1,8 +1,6 @@
-﻿using System.Text.Json.Serialization;
+﻿namespace BeyondImmersion.BannouService.Controllers.Messages;
 
-namespace BeyondImmersion.BannouService.Controllers.Messages;
-
-[Serializable]
+[JsonObject]
 public class ServiceResponse<T> : ServiceResponse
 where T : class, IServiceRequest
 {
@@ -13,10 +11,9 @@ where T : class, IServiceRequest
 /// <summary>
 /// The base class for service responses.
 /// </summary>
-[Serializable]
+[JsonObject]
 public class ServiceResponse : IServiceResponse
 {
-    [JsonIgnore]
     [HeaderArray(Name = "REQUEST_IDS")]
     public Dictionary<string, string> RequestIDs { get; set; }
 }

--- a/bannou-service/Program.cs
+++ b/bannou-service/Program.cs
@@ -119,6 +119,24 @@ public static class Program
                 {
                     mvcOptions.Filters.Add(typeof(HeaderArrayActionFilter));
                     mvcOptions.Filters.Add(typeof(HeaderArrayResultFilter));
+                }).
+                AddNewtonsoftJson(jsonSettings =>
+                {
+                    jsonSettings.SerializerSettings.ConstructorHandling = ConstructorHandling.Default;
+                    jsonSettings.SerializerSettings.DateFormatHandling = DateFormatHandling.IsoDateFormat;
+                    jsonSettings.SerializerSettings.DateParseHandling = DateParseHandling.DateTimeOffset;
+                    jsonSettings.SerializerSettings.DateTimeZoneHandling = DateTimeZoneHandling.Utc;
+                    jsonSettings.SerializerSettings.DefaultValueHandling = DefaultValueHandling.Include;
+                    jsonSettings.SerializerSettings.FloatFormatHandling = FloatFormatHandling.String;
+                    jsonSettings.SerializerSettings.FloatParseHandling = FloatParseHandling.Double;
+                    jsonSettings.SerializerSettings.MetadataPropertyHandling = MetadataPropertyHandling.Default;
+                    jsonSettings.SerializerSettings.MissingMemberHandling = MissingMemberHandling.Ignore;
+                    jsonSettings.SerializerSettings.NullValueHandling = NullValueHandling.Ignore;
+                    jsonSettings.SerializerSettings.PreserveReferencesHandling = PreserveReferencesHandling.None;
+                    jsonSettings.SerializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Error;
+                    jsonSettings.SerializerSettings.StringEscapeHandling = StringEscapeHandling.Default;
+                    jsonSettings.SerializerSettings.TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple;
+                    jsonSettings.SerializerSettings.TypeNameHandling = TypeNameHandling.None;
                 });
 
             webAppBuilder.Services.AddDaprClient();

--- a/bannou-service/Services/IDaprService.cs
+++ b/bannou-service/Services/IDaprService.cs
@@ -109,7 +109,7 @@ public interface IDaprService
             if (_serviceAppMappings == null)
             {
                 _serviceAppMappings = new Dictionary<string, IList<(Type, Type, DaprServiceAttribute)>>();
-                foreach ((Type, Type, DaprServiceAttribute) serviceHandler in IDaprService.Services)
+                foreach ((Type, Type, DaprServiceAttribute) serviceHandler in Services)
                 {
                     var serviceName = serviceHandler.Item3.Name;
                     var appName = Program.ConfigurationRoot.GetValue<string>(serviceName.ToUpper() + "_APP_MAPPING") ?? AppConstants.DEFAULT_APP_NAME;
@@ -174,7 +174,7 @@ public interface IDaprService
                             var configStr = File.ReadAllText(configFilePath);
                             if (configStr != null)
                             {
-                                var configPresets = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, string>>(configStr);
+                                var configPresets = JsonConvert.DeserializeObject<Dictionary<string, string>>(configStr);
                                 if (configPresets != null)
                                 {
                                     _networkModePresets = new Dictionary<string, string>(configPresets, StringComparer.InvariantCultureIgnoreCase);

--- a/bannou-service/Testing/Messages/TestingRunTestRequest.cs
+++ b/bannou-service/Testing/Messages/TestingRunTestRequest.cs
@@ -1,19 +1,14 @@
-﻿using BeyondImmersion.BannouService.Controllers.Messages;
-using System.Text.Json.Serialization;
-
-namespace BeyondImmersion.BannouService.Testing.Messages;
+﻿namespace BeyondImmersion.BannouService.Testing.Messages;
 
 /// <summary>
 /// The request model for service API calls to `/testing/run-test`.
 /// </summary>
-[Serializable]
+[JsonObject]
 public class TestingRunTestRequest : ServiceRequest
 {
-    [JsonInclude]
-    [JsonPropertyName("id")]
+    [JsonProperty("id")]
     public string? ID { get; set; }
 
-    [JsonInclude]
-    [JsonPropertyName("service")]
+    [JsonProperty("service")]
     public string? Service { get; set; }
 }

--- a/bannou-service/Usings.cs
+++ b/bannou-service/Usings.cs
@@ -5,5 +5,6 @@ global using BeyondImmersion.BannouService.Controllers;
 global using BeyondImmersion.BannouService.Controllers.Messages;
 global using BeyondImmersion.BannouService.Services;
 global using Microsoft.Extensions.Logging;
+global using Newtonsoft.Json;
 global using System.Collections.Generic;
 global using System.Linq;

--- a/bannou-service/bannou-service.csproj
+++ b/bannou-service/bannou-service.csproj
@@ -32,10 +32,13 @@
     <PackageReference Include="Dapr.Client" Version="1.12.0" />
     <PackageReference Include="Dapr.Extensions.Configuration" Version="1.12.0" />
     <PackageReference Include="JWT" Version="10.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.13" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
     <PackageReference Include="Serilog" Version="3.0.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="7.0.0" />

--- a/lib-accounts-core/AccountData.cs
+++ b/lib-accounts-core/AccountData.cs
@@ -1,50 +1,44 @@
-﻿using System.Text.Json.Serialization;
+﻿using Newtonsoft.Json;
 
 namespace BeyondImmersion.BannouService.Accounts;
 
-[Serializable]
+[JsonObject]
 public sealed class AccountData
 {
     /// <summary>
     /// The unique account ID (GUID).
     /// </summary>
-    [JsonInclude]
-    [JsonPropertyName("id")]
+    [JsonProperty("id")]
     public string? ID { get; }
 
     /// <summary>
     /// The account email address.
     /// </summary>
-    [JsonInclude]
-    [JsonPropertyName("email")]
+    [JsonProperty("email")]
     public string? Email { get; }
 
     /// <summary>
     /// The hash of the user's secret.
     /// </summary>
-    [JsonInclude]
-    [JsonPropertyName("hashed_secret")]
+    [JsonProperty("hashed_secret")]
     public string? HashedSecret { get; }
 
     /// <summary>
     /// The salt added to the user's secret before hashing.
     /// </summary>
-    [JsonInclude]
-    [JsonPropertyName("secret_salt")]
+    [JsonProperty("secret_salt")]
     public string? SecretSalt { get; }
 
     /// <summary>
     /// The account username.
     /// </summary>
-    [JsonInclude]
-    [JsonPropertyName("display_name")]
+    [JsonProperty("display_name")]
     public string? DisplayName { get; }
 
     /// <summary>
     /// The user's role claim.
     /// </summary>
-    [JsonInclude]
-    [JsonPropertyName("role")]
+    [JsonProperty("role")]
     public string? Role { get; }
 
     private AccountData() { }

--- a/lib-accounts-core/Messages/GetAccountRequest.cs
+++ b/lib-accounts-core/Messages/GetAccountRequest.cs
@@ -1,18 +1,17 @@
 ﻿using BeyondImmersion.BannouService.Controllers.Messages;
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 
 namespace BeyondImmersion.BannouService.Accounts.Messages;
 
 /// <summary>
 /// The request model for service API calls to `/account/get`.
 /// </summary>
-[Serializable]
+[JsonObject]
 public class GetAccountRequest : ServiceRequest<GetAccountResponse>
 {
     /// <summary>
     /// Email of account to retrieve.
     /// </summary>
-    [JsonInclude]
-    [JsonPropertyName("email")]
+    [JsonProperty("email")]
     public string? Email { get; set; }
 }

--- a/lib-accounts-core/Messages/GetAccountResponse.cs
+++ b/lib-accounts-core/Messages/GetAccountResponse.cs
@@ -1,35 +1,29 @@
 ﻿using BeyondImmersion.BannouService.Controllers.Messages;
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 
 namespace BeyondImmersion.BannouService.Accounts.Messages;
 
 /// <summary>
 /// The response model for service API calls to `/account/get`.
 /// </summary>
-[Serializable]
+[JsonObject]
 public class GetAccountResponse : ServiceResponse<GetAccountRequest>
 {
-    [JsonInclude]
-    [JsonPropertyName("id")]
+    [JsonProperty("id")]
     public string? ID { get; set; }
 
-    [JsonInclude]
-    [JsonPropertyName("email")]
+    [JsonProperty("email")]
     public string? Email { get; set; }
 
-    [JsonInclude]
-    [JsonPropertyName("display_name")]
+    [JsonProperty("display_name")]
     public string? DisplayName { get; set; }
 
-    [JsonInclude]
-    [JsonPropertyName("hashed_secret")]
+    [JsonProperty("hashed_secret")]
     public string? HashedSecret { get; set; }
 
-    [JsonInclude]
-    [JsonPropertyName("secret_salt")]
+    [JsonProperty("secret_salt")]
     public string? SecretSalt { get; set; }
 
-    [JsonInclude]
-    [JsonPropertyName("role")]
+    [JsonProperty("role")]
     public string? Role { get; set; }
 }

--- a/lib-auth-core/Messages/GetTokenRequest.cs
+++ b/lib-auth-core/Messages/GetTokenRequest.cs
@@ -1,11 +1,12 @@
 ﻿using BeyondImmersion.BannouService.Controllers.Messages;
+using Newtonsoft.Json;
 
 namespace BeyondImmersion.BannouService.Authorization.Messages;
 
 /// <summary>
 /// The request model for service API calls to `/authorization/token`.
 /// </summary>
-[Serializable]
+[JsonObject]
 public class GetTokenRequest : ServiceRequest<GetTokenResponse>
 {
 }

--- a/lib-auth-core/Messages/GetTokenResponse.cs
+++ b/lib-auth-core/Messages/GetTokenResponse.cs
@@ -1,5 +1,5 @@
 ﻿using BeyondImmersion.BannouService.Controllers.Messages;
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 
 namespace BeyondImmersion.BannouService.Authorization.Messages;
 
@@ -7,30 +7,25 @@ namespace BeyondImmersion.BannouService.Authorization.Messages;
 /// The response model for service API calls to `/authorization/token`.
 /// Does not use JRPC, as it's exposed directly to clients.
 /// </summary>
-[Serializable]
+[JsonObject]
 public class GetTokenResponse : ServiceResponse<GetTokenRequest>
 {
-    [Serializable]
+    [JsonObject]
     public class ErrorData
     {
-        [JsonInclude]
-        [JsonPropertyName("code")]
+        [JsonProperty("code")]
         public string? Code { get; set; }
 
-        [JsonInclude]
-        [JsonPropertyName("message")]
+        [JsonProperty("message")]
         public string? Message { get; set; }
 
-        [JsonInclude]
-        [JsonPropertyName("type")]
+        [JsonProperty("type")]
         public string? Type { get; set; }
     }
 
-    [JsonInclude]
-    [JsonPropertyName("token")]
+    [JsonProperty("token")]
     public string? Token { get; set; }
 
-    [JsonInclude]
-    [JsonPropertyName("errors")]
+    [JsonProperty("errors")]
     public ErrorData[]? Errors { get; set; }
 }

--- a/lib-auth-core/Messages/ValidateTokenRequest.cs
+++ b/lib-auth-core/Messages/ValidateTokenRequest.cs
@@ -1,15 +1,14 @@
 ﻿using BeyondImmersion.BannouService.Controllers.Messages;
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 
 namespace BeyondImmersion.BannouService.Authorization.Messages;
 
 /// <summary>
 /// The request model for service API calls to `/authorization/validate`.
 /// </summary>
-[Serializable]
+[JsonObject]
 public class ValidateTokenRequest : ServiceRequest<ValidateTokenResponse>
 {
-    [JsonInclude]
-    [JsonPropertyName("token")]
+    [JsonProperty("token")]
     public string? Token { get; set; }
 }

--- a/lib-auth-core/Messages/ValidateTokenResponse.cs
+++ b/lib-auth-core/Messages/ValidateTokenResponse.cs
@@ -1,35 +1,30 @@
 ﻿using BeyondImmersion.BannouService.Controllers.Messages;
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 
 namespace BeyondImmersion.BannouService.Authorization.Messages;
 
 /// <summary>
 /// The response model for service API calls to `/authorization/validate`.
 /// </summary>
-[Serializable]
+[JsonObject]
 public class ValidateTokenResponse : ServiceResponse<ValidateTokenRequest>
 {
-    [Serializable]
+    [JsonObject]
     public class ErrorData
     {
-        [JsonInclude]
-        [JsonPropertyName("code")]
+        [JsonProperty("code")]
         public string? Code { get; set; }
 
-        [JsonInclude]
-        [JsonPropertyName("message")]
+        [JsonProperty("message")]
         public string? Message { get; set; }
 
-        [JsonInclude]
-        [JsonPropertyName("type")]
+        [JsonProperty("type")]
         public string? Type { get; set; }
     }
 
-    [JsonInclude]
-    [JsonPropertyName("token")]
+    [JsonProperty("token")]
     public string? Token { get; set; }
 
-    [JsonInclude]
-    [JsonPropertyName("errors")]
+    [JsonProperty("errors")]
     public ErrorData[]? Errors { get; set; }
 }

--- a/lib-connect-core/Messages/ConnectRequest.cs
+++ b/lib-connect-core/Messages/ConnectRequest.cs
@@ -1,11 +1,12 @@
 ﻿using BeyondImmersion.BannouService.Controllers.Messages;
+using Newtonsoft.Json;
 
 namespace BeyondImmersion.BannouService.Connect.Messages;
 
 /// <summary>
 /// The request model for service API calls to `/connect`.
 /// </summary>
-[Serializable]
+[JsonObject]
 public class ConnectRequest : ServiceRequest<ServiceResponse>
 {
 }

--- a/lib-connect-core/Messages/ConnectResponse.cs
+++ b/lib-connect-core/Messages/ConnectResponse.cs
@@ -1,4 +1,5 @@
 ﻿using BeyondImmersion.BannouService.Controllers.Messages;
+using Newtonsoft.Json;
 
 namespace BeyondImmersion.BannouService.Connect.Messages;
 
@@ -6,7 +7,7 @@ namespace BeyondImmersion.BannouService.Connect.Messages;
 /// The response model for service API calls to `/connect`.
 /// Does not use JRPC, as it's exposed directly to clients.
 /// </summary>
-[Serializable]
+[JsonObject]
 public class ConnectResponse : ServiceResponse<ConnectRequest>
 {
 }


### PR DESCRIPTION
## Reason for update

Use Newtonsoft.Json for serializing to and from strings.

It's very likely that libs will be using JObjects and JWTs rather commonly, so best to put it in the main project/application, and if we're going to have it for text serialization, better to just use it for ALL text serialization.

Integrating with MVC controllers to consume/produce using Newtonsoft automatically. Ensuring the action filter / result filter for header arrays work after the change- existing integration tests are sufficient for this.