### PR TITLE
Fix CI build failures in SDKs

### DIFF
--- a/sdks/asset-bundler/Upload/BannouUploader.cs
+++ b/sdks/asset-bundler/Upload/BannouUploader.cs
@@ -333,9 +333,9 @@ public sealed class BannouUploader : IAssetUploader, IAsyncDisposable
         if (requiredHeaders == null || requiredHeaders.Count == 0)
         {
             // Default content type if no headers specified
-            if (request.Content != null)
+            if (request.Content is { Headers: { } headers })
             {
-                request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/x-bannou-bundle");
+                headers.ContentType = new MediaTypeHeaderValue("application/x-bannou-bundle");
             }
             return;
         }

--- a/sdks/client-voice/VoiceRoomManager.cs
+++ b/sdks/client-voice/VoiceRoomManager.cs
@@ -105,7 +105,10 @@ public sealed class VoiceRoomManager : IDisposable
             }
 
             // Apply to scaled connection
-            _scaledConnection?.IsMuted = value;
+            if (_scaledConnection != null)
+            {
+                _scaledConnection.IsMuted = value;
+            }
         }
     }
     private bool _isMuted;

--- a/sdks/client.tests/TypedApi/EventSubscriptionTests.cs
+++ b/sdks/client.tests/TypedApi/EventSubscriptionTests.cs
@@ -153,7 +153,7 @@ public class EventSubscriptionTests
     // =========================================================================
 
     [Fact]
-    public void Dispose_ConcurrentCalls_OnlyInvokesCallbackOnce()
+    public async Task Dispose_ConcurrentCalls_OnlyInvokesCallbackOnce()
     {
         var callbackCount = 0;
         var subscription = new EventSubscription(
@@ -166,7 +166,7 @@ public class EventSubscriptionTests
             .Select(_ => Task.Run(() => subscription.Dispose()))
             .ToArray();
 
-        Task.WaitAll(tasks);
+        await Task.WhenAll(tasks);
 
         // Callback should only be invoked once despite concurrent disposal attempts
         Assert.Equal(1, callbackCount);

--- a/sdks/server/Bannou.Server.csproj
+++ b/sdks/server/Bannou.Server.csproj
@@ -95,6 +95,15 @@
     <Compile Include="../client/RemoteAssetCache.cs" />
     <Compile Include="../client/MetaTypes.cs" />
     <Compile Include="../client/ResponseCodes.cs" />
+    <Compile Include="../client/IEventSubscription.cs" />
+    <Compile Include="../client/EventSubscription.cs" />
+  </ItemGroup>
+
+  <!-- Generated Event Infrastructure from Client SDK -->
+  <ItemGroup>
+    <Compile Include="../client/Generated/Events/*.cs" />
+    <Compile Include="../client/Generated/Proxies/*.cs" />
+    <Compile Include="../client/Generated/BannouClientProxyExtensions.cs" />
   </ItemGroup>
 
   <!-- Behavior Runtime (copied from lib-behavior with SDK namespace) -->


### PR DESCRIPTION
## Summary
- Fixed Server SDK missing Client SDK event infrastructure files (Events namespace, IEventSubscription, proxies)
- Fixed IDE0031 null check simplification warning in BannouUploader.cs using pattern matching
- Fixed xUnit1031 blocking task warning in EventSubscriptionTests.cs using async/await
- Fixed CS8652 preview feature usage (null-conditional assignment) in VoiceRoomManager.cs

## Context
After merging PR #110 (Client SDK Typed APIs), the GitHub Actions CI build failed because:
1. Server SDK shares source files with Client SDK but was missing the new event-related files
2. Several analyzer warnings were being treated as errors

## Test plan
- [x] Local build of `bannou-sdks.sln` - 0 errors, 0 warnings
- [x] Local build of main solution - 0 errors, 0 warnings
- [ ] CI build should pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)