### PR TITLE
Fix non-existent Stride.Assets.Media package reference in project generator

### DIFF
--- a/sdks/asset-bundler-stride/Compilation/StrideBatchProjectGenerator.cs
+++ b/sdks/asset-bundler-stride/Compilation/StrideBatchProjectGenerator.cs
@@ -169,8 +169,7 @@ public sealed class StrideBatchProjectGenerator
 
               <ItemGroup>
                 <PackageReference Include="Stride.Core.Assets.CompilerApp" Version="{strideVersion}" />
-                <PackageReference Include="Stride.Assets.Models" Version="{strideVersion}" />
-                <PackageReference Include="Stride.Assets.Media" Version="{strideVersion}" />
+                <PackageReference Include="Stride.Assets" Version="{strideVersion}" />
               </ItemGroup>
             </Project>
             """;


### PR DESCRIPTION
## Summary
- Removed non-existent `Stride.Assets.Media` package from generated project files
- Replaced with `Stride.Assets` which includes all asset types (models, textures, sounds, animations)

## Problem
`StrideBatchProjectGenerator.cs` generates temporary .csproj files for Stride asset compilation that referenced:
- `Stride.Core.Assets.CompilerApp` ✅ (exists)
- `Stride.Assets.Models` ✅ (exists)  
- `Stride.Assets.Media` ❌ (does NOT exist on NuGet)

This would cause runtime failures when anyone tried to use the asset bundler.

## Fix
Use `Stride.Assets` which includes model, texture, sound, video, and animation asset types. `Stride.Assets.Models` was also redundant since it's a transitive dependency.

## Test plan
- [x] Build passes
- [x] Verified `Stride.Assets` exists on NuGet with correct dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)